### PR TITLE
1.[add]增加微信服务器请求代理

### DIFF
--- a/endpoints/wechat/api/custom_message.py
+++ b/endpoints/wechat/api/custom_message.py
@@ -11,16 +11,18 @@ class WechatCustomMessageSender:
     
     TOKEN_CACHE = {}  # for caching access token
     
-    def __init__(self, app_id: str, app_secret: str):
+    def __init__(self, app_id: str, app_secret: str, api_base_url: str = None):
         """
         initialize custom message sender
         
         params:
             app_id: wechat public account app id
             app_secret: wechat public account app secret
+            api_base_url: wechat api base url, default is api.weixin.qq.com
         """
         self.app_id = app_id
         self.app_secret = app_secret
+        self.api_base_url = api_base_url or "api.weixin.qq.com"
     
     def _get_access_token(self) -> str:
         """
@@ -41,7 +43,7 @@ class WechatCustomMessageSender:
                 return token_info['token']
         
         # request new access token
-        url = f"https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid={self.app_id}&secret={self.app_secret}"
+        url = f"https://{self.api_base_url}/cgi-bin/token?grant_type=client_credential&appid={self.app_id}&secret={self.app_secret}"
         
         try:
             response = requests.get(url, timeout=10)
@@ -84,7 +86,7 @@ class WechatCustomMessageSender:
             access_token = self._get_access_token()
             
             # build request url
-            url = f"https://api.weixin.qq.com/cgi-bin/message/custom/send?access_token={access_token}"
+            url = f"https://{self.api_base_url}/cgi-bin/message/custom/send?access_token={access_token}"
             
             # build request data
             data = {
@@ -125,4 +127,4 @@ class WechatCustomMessageSender:
             return {
                 'success': False,
                 'error': str(e)
-            } 
+            }

--- a/endpoints/wechat/handlers/voice.py
+++ b/endpoints/wechat/handlers/voice.py
@@ -23,6 +23,7 @@ class VoiceMessageHandler(MessageHandler):
         # 微信公众号配置
         app_id = app_settings.get("app_id")
         app_secret = app_settings.get("app_secret")
+        wechat_api_proxy_url = app_settings.get("wechat_api_proxy_url")
         logger.info("application configuration: %s", app_settings)
         if not app_id or not app_secret:
             logger.error("missing wechat public account configuration")
@@ -49,7 +50,7 @@ class VoiceMessageHandler(MessageHandler):
         
         # get voice file content
         try:
-            media_manager = WechatMediaManager(app_id, app_secret, session.storage)
+            media_manager = WechatMediaManager(app_id, app_secret, wechat_api_proxy_url, session.storage)
             
             # check if using high-quality voice
             media_type = "jssdk" if message.format == "speex" else "normal"

--- a/endpoints/wechat_post.py
+++ b/endpoints/wechat_post.py
@@ -300,13 +300,14 @@ class WechatPost(Endpoint):
             # check if the configuration has the parameters required for customer message
             app_id = settings.get('app_id')
             app_secret = settings.get('app_secret')
+            wechat_api_proxy_url = settings.get('wechat_api_proxy_url')
             
             if not app_id or not app_secret:
                 logger.error("customer message: missing app_id or app_secret configuration")
                 return
 
             # initialize the customer message sender and send the message
-            sender = WechatCustomMessageSender(app_id, app_secret)
+            sender = WechatCustomMessageSender(app_id, app_secret, wechat_api_proxy_url)
             logger.debug(f"customer message: sending to user {message.from_user}, content length: {len(content)}")
             
             send_result = sender.send_text_message(

--- a/group/wechat_sub.yaml
+++ b/group/wechat_sub.yaml
@@ -6,6 +6,12 @@ settings:
     label:
       en_US: App
       zh_Hans: App
+  - name: wechat_api_proxy_url
+    type: text-input
+    required: false
+    label:
+      en_US: Wechat API Proxy URL
+      zh_Hans: 微信API代理地址(可选,默认api.weixin.qq.com)
   - name: wechat_token
     type: secret-input
     required: true


### PR DESCRIPTION
，可以在配置时候设置代理，不直接请求：api.weixin.qq.com，而是通过制定代理服务器进行请求注意要是https，我只替换了域名，这样就可以绕过微信服务器白名单IP要求，主要是用来解决应用服务器在内网环境中，但是微信服务器白名单IP要求是指定外网IP